### PR TITLE
Create stylesheet config of colors

### DIFF
--- a/app/assets/stylesheets/config/_colors.scss
+++ b/app/assets/stylesheets/config/_colors.scss
@@ -1,0 +1,3 @@
+$blue:rgb(50, 200,220);
+$light-blue:rgb(70, 220, 240);
+$orange:rgb(250, 170, 40);


### PR DESCRIPTION
# What
Stylesheetフォルダに、configフォルダを作成。
configフォルダに、_colors.scssファイルを作成。

# Why
scssファイルで、良く使用する「色」を直ぐに呼び出しできるようにするため。